### PR TITLE
Fix compression check

### DIFF
--- a/src/data/sequence_file.cpp
+++ b/src/data/sequence_file.cpp
@@ -289,7 +289,7 @@ void SequenceFile::load_dictionary(const size_t query_block, const size_t ref_bl
 			dict_self_aln_score_ = vector<vector<double>>(ref_blocks);
 		reserve_dict(ref_blocks);
 		for (size_t i = 0; i < ref_blocks; ++i) {
-			InputFile f(dict_file_name(query_block, i), 4);
+			InputFile f(dict_file_name(query_block, i), InputFile::NO_COMPRESSION_CHECK);
 			load_dict_block(&f, i);
 			f.close_and_delete();
 		}

--- a/src/data/sequence_file.cpp
+++ b/src/data/sequence_file.cpp
@@ -289,7 +289,7 @@ void SequenceFile::load_dictionary(const size_t query_block, const size_t ref_bl
 			dict_self_aln_score_ = vector<vector<double>>(ref_blocks);
 		reserve_dict(ref_blocks);
 		for (size_t i = 0; i < ref_blocks; ++i) {
-			InputFile f(dict_file_name(query_block, i));
+			InputFile f(dict_file_name(query_block, i), 4);
 			load_dict_block(&f, i);
 			f.close_and_delete();
 		}

--- a/src/util/io/input_file.cpp
+++ b/src/util/io/input_file.cpp
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static Compressor detect_compressor(const char* b) {
 	if ((b[0] == '\x1F' && b[1] == '\x8B')         // gzip header
 		|| (b[0] == '\x78' && (b[1] == '\x01'      // zlib header
-			|| b[1] == '\x9C'
+		        || b[1] == '\x9C'
 			|| b[1] == '\xDA')))
 		return Compressor::ZLIB;
 	if (b[0] == '\x28' && b[1] == '\xb5' && b[2] == '\x2f' && b[3] == '\xfd')
@@ -91,7 +91,7 @@ InputFile::InputFile(const string &file_name, int flags) :
 	if (n < 4)
 		return;
 	const auto c = detect_compressor(b);
-	if(c != Compressor::NONE)
+	if(c != Compressor::NONE && !(flags & NO_COMPRESSION_CHECK))
 		buffer_ = new InputStreamBuffer(make_decompressor(c, buffer_));
 }
 

--- a/src/util/io/input_file.cpp
+++ b/src/util/io/input_file.cpp
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static Compressor detect_compressor(const char* b) {
 	if ((b[0] == '\x1F' && b[1] == '\x8B')         // gzip header
 		|| (b[0] == '\x78' && (b[1] == '\x01'      // zlib header
-		        || b[1] == '\x9C'
+			|| b[1] == '\x9C'
 			|| b[1] == '\xDA')))
 		return Compressor::ZLIB;
 	if (b[0] == '\x28' && b[1] == '\xb5' && b[2] == '\x2f' && b[3] == '\xfd')

--- a/src/util/io/input_file.h
+++ b/src/util/io/input_file.h
@@ -39,7 +39,7 @@ const size_t KILOBYTES = 1 << 10;
 struct InputFile : public Deserializer
 {
 
-	enum { BUFFERED = 1, NO_AUTODETECT = 2 };
+	enum { BUFFERED = 1, NO_AUTODETECT = 2, NO_COMPRESSION_CHECK = 4};
 
 	InputFile(const string &file_name, int flags = 0);
 	InputFile(TempFile &tmp_file, int flags = 0);


### PR DESCRIPTION
* This should fix the bug where the db is being read in as a zlib file
* Disables the compression check for the load_dictionary call
* Creates a new NO_COMPRESSION_CHECK flag